### PR TITLE
CLI - Supporting older versions

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,5 @@
 kafka:
-  broker: kafka:9093
-
+    broker: kafka:9093
+    version: 3.9.0
 openkommander:
-  session_filename: .openkommander_config
+    session_filename: .openkommander_config

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -3,8 +3,8 @@ package cluster
 import (
 	"context"
 	"fmt"
-
 	"github.com/IBM/sarama"
+	"github.com/spf13/viper"
 )
 
 type Cluster struct {
@@ -14,7 +14,8 @@ type Cluster struct {
 
 func NewCluster(brokers []string) *Cluster {
 	config := sarama.NewConfig()
-	config.Version = sarama.V3_9_0_0
+	defaultVersion := viper.GetString("kafka.version")
+	config.Version, _ = sarama.ParseKafkaVersion(defaultVersion)
 	return &Cluster{
 		Brokers: brokers,
 		Config:  config,


### PR DESCRIPTION
- Introduced kafka version property in config.yaml
- Using viper to set the version locally thru user input and updating the config.yaml subsequently
- Reading version from config file using viper