### PR TITLE
Update deprecated Kafka image in Docker Compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
 
   kafka:
     container_name: kafka
-    image: bitnami/kafka:4.0.0
+    image: bitnamilegacy/kafka:4.0.0
     ports:
       - "9092:9092"
       - "9093:9093"


### PR DESCRIPTION
- Updated docker-compose.dev to use bitnamilegacy repo instead of priorlegacy bitnami

Closes #97 